### PR TITLE
add teams presence

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,7 @@ verify_ssl = true
 [dev-packages]
 
 [packages]
-o365 = "==2.0.9"
+o365 = "==2.0.14"
 beautifulsoup4 = "==4.9.0"
 
 [requires]

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Under "Api Permissions" add the following delegated permission from the Microsof
 * Mail.ReadWrite.Shared - *Read and write user and shared mail*
 * Mail.Send - *Send mail as a user*
 * Mail.Send.Shared - *Send mail on behalf of others*
+* Presence.Read - *Allow access to teams status*
 
 ## Adding to Home Assistant
 

--- a/custom_components/o365/manifest.json
+++ b/custom_components/o365/manifest.json
@@ -4,5 +4,5 @@
     "documentation": "https://github.com/PTST/O365Calendar-HomeAssistant",
     "dependencies": ["configurator", "http"],
     "codeowners": ["@PTST"],
-    "requirements": ["O365==2.0.9", "BeautifulSoup4==4.8.2"]
+    "requirements": ["O365==2.0.14", "BeautifulSoup4==4.8.2"]
   }

--- a/custom_components/o365/sensor.py
+++ b/custom_components/o365/sensor.py
@@ -190,9 +190,7 @@ class O365TeamsStatusSensor(Entity):
     def __init__(self, account, conf):
         self.account = account
         self.teams = account.teams()
-        self._name = conf.get(
-            CONF_NAME, f"{self.account.get_current_user().mail}-teams status"
-        )
+        self._name = f"{self.account.get_current_user().mail}-teams status"
         self._state = 0
         self._attributes = {}
 

--- a/custom_components/o365/sensor.py
+++ b/custom_components/o365/sensor.py
@@ -39,6 +39,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         sensor = O365QuerySensor(account, conf)
         add_devices([sensor], True)
 
+    teamsStatusSensor = O365TeamsStatusSensor(account, conf)
+    add_devices([teamsStatusSensor], True)
 
 class O365QuerySensor(Entity):
     def __init__(self, account, conf):
@@ -183,3 +185,28 @@ class O365InboxSensor(Entity):
         self._state = len(mails)
         # self._attributes = {"data": attrs, "data_str_repr": json.dumps(attrs)}
         self._attributes = {"data": attrs}
+
+class O365TeamsStatusSensor(Entity):
+    def __init__(self, account, conf):
+        self.account = account
+        self.teams = account.teams()
+        self._name = conf.get(
+            CONF_NAME, f"{self.account.get_current_user().mail}-teams status"
+        )
+        self._state = 0
+        self._attributes = {}
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def state(self):
+        return self._state
+
+    @property
+    def device_state_attributes(self):
+        return self._attributes
+    
+    def update(self):
+        self._state = self.teams.get_my_presence().activity


### PR DESCRIPTION
I'd Like to add teams presence to home assistant using the account setup already provided by o365,

However i'm actually unsure on how to locally test this. I know this works upstream in the O365 lib, but i'm not familiar enough with home assistant to figure out what i'm doing wrong.

Anyone who can help? 