### PR TITLE
All day event timezone fix

### DIFF
--- a/custom_components/o365/calendar.py
+++ b/custom_components/o365/calendar.py
@@ -1,7 +1,9 @@
 import logging
 import copy
 from operator import attrgetter, itemgetter
-from datetime import timedelta, datetime
+from datetime import timedelta, datetime, tzinfo
+from pytz import timezone
+import pytz
 from homeassistant.util import Throttle, dt
 from homeassistant.components.calendar import (
     CalendarEventDevice,
@@ -191,8 +193,12 @@ class O365CalendarData:
         event_list = []
         for event in vevent_list:
             data = format_event_data(event, self.calendar.calendar_id)
-            data["start"] = self.get_hass_date(data["start"])
-            data["end"] = self.get_hass_date(data["end"])
+            if not data["is_all_day"]:
+                data["start"] = self.get_hass_date(data["start"])
+                data["end"] = self.get_hass_date(data["end"])
+            else:             
+                data["start"] = self.get_hass_date(data["start"].astimezone(pytz.utc).date()) 
+                data["end"] = self.get_hass_date((data["end"].astimezone(pytz.utc).date())) 
             event_list.append(data)
 
         return event_list
@@ -249,8 +255,9 @@ class O365CalendarData:
             if obj.tzinfo is None:
                 return obj.replace(tzinfo=dt.DEFAULT_TIME_ZONE)
             return obj
-        return dt.as_local(dt.dt.datetime.combine(obj, dt.dt.time.min))
-
+        return dt.dt.datetime.combine(obj, dt.dt.time.min).replace(
+            tzinfo=dt.DEFAULT_TIME_ZONE
+        )
     @staticmethod
     def get_end_date(obj):
         if hasattr(obj, "end"):


### PR DESCRIPTION
Attempts to fix PTST/O365-HomeAssistant#85
Two changes:
1. Bring in fix from home-assistant/core#48642 which doesn't make much of a difference here (branch doesn't appear to get hit with all day events).
1. Fix the timezone shift for all day events. I'm not sure this is in the right place since it appears o365 is returning the event as if it were on GMT (but it's not). This may only work if the all day event was actually in the local timezone.